### PR TITLE
Add prefix to table name.

### DIFF
--- a/Observer/Config.php
+++ b/Observer/Config.php
@@ -74,6 +74,7 @@ class Config implements ObserverInterface
             $databaseFailure = false;
 
             foreach ($this->desiredDatabaseStructure as $table => $columns) {
+                $table = $this->resource->getTableName($table);
                 if (!$connection->isTableExists($table)) {
                     $databaseFailure = true;
                     break;


### PR DESCRIPTION
Fixes issue that displays the error message when Magento tables have a database prefix. (See #20)