### PR TITLE
3.6.2 Bug fixes

### DIFF
--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -124,10 +124,20 @@ class Index extends Action
         $requestJson = json_decode($request);
 
         if (json_last_error() == JSON_ERROR_NONE) {
-            // Test is only verifying that the endpoint is reachable. So we just complete here
-            if ($topic === 'cases/test') {
-                $this->getResponse()->setStatusCode(Http::STATUS_CODE_200);
-                return;
+            switch (($topic)) {
+                case 'cases/test':
+                    // Test is only verifying that the endpoint is reachable. So we just complete here
+                    $this->getResponse()->setStatusCode(Http::STATUS_CODE_200);
+                    return;
+                    break;
+
+                case 'cases/creation':
+                    $message = 'Case creation will not be processed by Magento';
+                    $this->getResponse()->appendBody($message);
+                    $this->logger->debug("API: {$message}");
+                    $this->getResponse()->setStatusCode(Http::STATUS_CODE_200);
+                    return;
+                    break;
             }
 
             /** @var $order \Magento\Sales\Model\Order */

--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -129,7 +129,6 @@ class Index extends Action
                     // Test is only verifying that the endpoint is reachable. So we just complete here
                     $this->getResponse()->setStatusCode(Http::STATUS_CODE_200);
                     return;
-                    break;
 
                 case 'cases/creation':
                     $message = 'Case creation will not be processed by Magento';
@@ -137,7 +136,6 @@ class Index extends Action
                     $this->logger->debug("API: {$message}");
                     $this->getResponse()->setStatusCode(Http::STATUS_CODE_200);
                     return;
-                    break;
             }
 
             /** @var $order \Magento\Sales\Model\Order */

--- a/Helper/FulfillmentHelper.php
+++ b/Helper/FulfillmentHelper.php
@@ -253,7 +253,8 @@ class FulfillmentHelper
         foreach ($trackingCollection->getItems() as $tracking) {
             $number = trim($tracking->getNumber());
 
-            if (empty($number) === false && is_object($number) === false && is_array($number) === false) {
+            if (empty($number) === false && is_object($number) === false && is_array($number) === false &&
+                in_array($number, $trackingNumbers) == false) {
                 $trackingNumbers[] = $number;
             }
         }

--- a/Helper/FulfillmentHelper.php
+++ b/Helper/FulfillmentHelper.php
@@ -253,8 +253,8 @@ class FulfillmentHelper
         foreach ($trackingCollection->getItems() as $tracking) {
             $number = trim($tracking->getNumber());
 
-            if (empty($number) == false) {
-                $trackingNumbers[] = $tracking->getNumber();
+            if (empty($number) === false && is_object($number) === false && is_array($number) === false) {
+                $trackingNumbers[] = $number;
             }
         }
 

--- a/Helper/PurchaseHelper.php
+++ b/Helper/PurchaseHelper.php
@@ -249,15 +249,6 @@ class PurchaseHelper
         return $shipments;
     }
 
-    public function isAdmin()
-    {
-        /** @var \Magento\Framework\ObjectManagerInterface $om */
-        $om = \Magento\Framework\App\ObjectManager::getInstance();
-        /** @var \Magento\Framework\App\State $state */
-        $state =  $om->get(\Magento\Framework\App\State::class);
-        return 'adminhtml' === $state->getAreaCode();
-    }
-
     /**
      * @param $mageAddress Address
      * @return SignifydAddress

--- a/Observer/Order/Save/Before.php
+++ b/Observer/Order/Save/Before.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Signifyd\Connect\Observer\Order\Save;
+
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\Order;
+use Magento\Store\Model\StoreManagerInterface;
+use Signifyd\Connect\Logger\Logger;
+use Signifyd\Connect\Helper\ConfigHelper;
+use Signifyd\Connect\Helper\PurchaseHelper;
+
+class Before implements ObserverInterface
+{
+    /**
+     * @var Logger;
+     */
+    protected $logger;
+
+    /**
+     * @var AppState
+     */
+    protected $appState;
+
+    /**
+     * @var ConfigHelper
+     */
+    protected $configHelper;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * Before constructor.
+     * @param Logger $loger
+     * @param AppState $appState
+     * @param ConfigHelper $configHelper
+     * @param StoreManagerInterface $storeManager
+     * @param RequestInterface $request
+     */
+    public function __construct(
+        Logger $loger,
+        AppState $appState,
+        ConfigHelper $configHelper,
+        StoreManagerInterface $storeManager,
+        RequestInterface $request
+    ) {
+        $this->logger = $loger;
+        $this->appState = $appState;
+        $this->configHelper = $configHelper;
+        $this->storeManager = $storeManager;
+        $this->request = $request;
+    }
+
+    /**
+     * @param Observer $observer
+     * @param bool $checkOwnEventsMethods
+     */
+    public function execute(Observer $observer, $checkOwnEventsMethods = true)
+    {
+        try {
+            /** @var $order Order */
+            $order = $observer->getEvent()->getOrder();
+
+            if (!is_object($order)) {
+                return;
+            }
+
+            if ($this->configHelper->isEnabled($order) == false) {
+                return;
+            }
+
+            // Saving store code to order, to know where the order is been created
+            if (empty($order->getData('origin_store_code')) && is_object($this->storeManager)) {
+                $isAdmin = ('adminhtml' === $this->appState->getAreaCode());
+                $storeCode = $this->storeManager->getStore($isAdmin ? 'admin' : true)->getCode();
+
+                if (!empty($storeCode)) {
+                    $order->setData('origin_store_code', $storeCode);
+                }
+            }
+
+            // Fix for Magento bug https://github.com/magento/magento2/issues/7227
+            // x_forwarded_for should be copied from quote, but quote does not have the field on database
+            if (empty($order->getData('x_forwarded_for')) && is_object($this->request)) {
+                $xForwardIp = $this->request->getServer('HTTP_X_FORWARDED_FOR');
+
+                if (empty($xForwardIp) == false) {
+                    $order->setData('x_forwarded_for', $xForwardIp);
+                }
+            }
+        } catch (\Exception $ex) {
+            $context = [];
+
+            if (isset($order) && $order instanceof Order) {
+                $context['entity'] = $order;
+            }
+
+            $this->logger->error($ex->getMessage(), $context);
+        }
+    }
+}

--- a/Observer/Purchase.php
+++ b/Observer/Purchase.php
@@ -198,6 +198,9 @@ class Purchase implements ObserverInterface
                     $case->save();
                     $message = 'Case for order:#' . $incrementId . ' was not sent because of an async payment method';
                     $this->logger->debug($message);
+
+                    // Initial hold order
+                    $this->holdOrder($order);
                 } catch (\Exception $ex) {
                     $this->logger->error($ex->__toString());
                 }

--- a/Observer/Purchase.php
+++ b/Observer/Purchase.php
@@ -23,12 +23,12 @@ use Magento\Framework\App\RequestInterface;
 class Purchase implements ObserverInterface
 {
     /**
-     * @var \Signifyd\Connect\Logger\Logger;
+     * @var Logger;
      */
     protected $logger;
 
     /**
-     * @var \Signifyd\Connect\Helper\PurchaseHelper
+     * @var PurchaseHelper
      */
     protected $helper;
 
@@ -124,33 +124,6 @@ class Purchase implements ObserverInterface
 
             if ($this->configHelper->isEnabled($order) == false) {
                 return;
-            }
-
-            $saveOrder = false;
-
-            // Saving store code to order, to know where the order is been created
-            if (empty($order->getData('origin_store_code')) && is_object($this->storeManager)) {
-                $storeCode = $this->storeManager->getStore($this->helper->isAdmin() ? 'admin' : true)->getCode();
-
-                if (!empty($storeCode)) {
-                    $order->setData('origin_store_code', $storeCode);
-                    $saveOrder = true;
-                }
-            }
-
-            // Fix for Magento bug https://github.com/magento/magento2/issues/7227
-            // x_forwarded_for should be copied from quote, but quote does not have the field on database
-            if (empty($order->getData('x_forwarded_for')) && is_object($this->request)) {
-                $xForwardIp = $this->request->getServer('HTTP_X_FORWARDED_FOR');
-
-                if (empty($xForwardIp) == false) {
-                    $order->setData('x_forwarded_for', $xForwardIp);
-                    $saveOrder = true;
-                }
-            }
-
-            if ($saveOrder) {
-                $order->save();
             }
 
             // Check if a payment is available for this order yet

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=5.5.22"
   },
   "type": "magento2-module",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "autoload": {
     "files": [
       "registration.php"

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -8,6 +8,10 @@
         <observer name="signifydDebugLogs" instance="Signifyd\Connect\Observer\Debug\Order" />
     </event>
 
+    <event name="sales_order_save_before">
+        <observer name="orderSaveBefore" instance="Signifyd\Connect\Observer\Order\Save\Before" />
+    </event>
+
     <event name="checkout_submit_all_after">
         <observer name="onCheckout" instance="Signifyd\Connect\Observer\Purchase" />
     </event>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Signifyd_Connect" setup_version="3.6.1">
+    <module name="Signifyd_Connect" setup_version="3.6.2">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
- Avoid send duplicated tracking numbers
- Do not process 'case/creation' webhook event to avoid race condition issues on case creation
- Hold orders using async payment methods
- Avoid re-trigger order save on case creation, used before order save event instead
- Fix to do not duplicate gift card generation on built in Magento Commerce functionality
- Properly process cases with Stripe official extension 1.8.8 and above on multi-store environment