### PR TITLE
Fix null reference error

### DIFF
--- a/Helper/PurchaseHelper.php
+++ b/Helper/PurchaseHelper.php
@@ -242,7 +242,7 @@ class PurchaseHelper
         $itemPrice = floatval(number_format($item->getPrice(), 0, '.', ''));
 
         if ($itemPrice <= 0) {
-            if ($item->getParentItem()->getProductType() === 'configurable') {
+            if ($item->getParentItem() && $item->getParentItem()->getProductType() === 'configurable') {
                 $itemPrice = $item->getParentItem()->getPrice();
             }
         }


### PR DESCRIPTION
Fixed an issue in PurchaseHelper.php where $item->getParentItem() sometimes returns null. This is the case if the customer is checking out with a free product. Example: buy 2 shirts and get a free hat.