### PR TITLE
Fix to send Shipping Method object instead of shipping method as string

### DIFF
--- a/Helper/FulfillmentHelper.php
+++ b/Helper/FulfillmentHelper.php
@@ -227,7 +227,7 @@ class FulfillmentHelper
         $fulfillment['confirmationName'] = null;
         $fulfillment['confirmationPhone'] = null;
         $fulfillment['shippingCarrier'] = $this->purchaseHelper
-            ->makeShipper($shipment->getOrder()->getShippingMethod());
+            ->makeShipper($shipment->getOrder()->getShippingMethod(true));
 
         return $fulfillment;
     }


### PR DESCRIPTION
MakeShipper method expects Shipping Object, however, it's currently passing string value.  The method getOrder()->getShippingMethod(true) returns shipping object containing carrier code and shipping method.