### PR TITLE
Fix unserialize error when empty string passed to unserilize function

### DIFF
--- a/Observer/PreAuth.php
+++ b/Observer/PreAuth.php
@@ -148,7 +148,13 @@ class PreAuth implements ObserverInterface
 
         $paymentMethod = null;
         $data = $this->requestHttp->getContent();
-        $dataArray = $this->jsonSerializer->unserialize($data);
+
+        try {
+            $dataArray = $this->jsonSerializer->unserialize($data);
+        } catch (\Exception $e) {
+            $dataArray = [];
+            $this->logger->debug('Unable to unserialize value. Empty data passed to unserialize function.');
+        }
 
         if (isset($dataArray['paymentMethod']) &&
             isset($dataArray['paymentMethod']['method'])


### PR DESCRIPTION
The magento core unserialize function throws an error if the string passed to is empty.
The PreAuth Observer class was missing try catch block. Hence, added it.