### PR TITLE
Fix Braintree Compilation Error - GeneralResponseValidator.php

### DIFF
--- a/Plugin/Braintree/Gateway/Validator/GeneralResponseValidator.php
+++ b/Plugin/Braintree/Gateway/Validator/GeneralResponseValidator.php
@@ -2,7 +2,7 @@
 
 namespace Signifyd\Connect\Plugin\Braintree\Gateway\Validator;
 
-use Magento\Braintree\Gateway\SubjectReader;
+use PayPal\Braintree\Gateway\Helper\SubjectReader;
 use Signifyd\Connect\Helper\PurchaseHelper;
 use Signifyd\Connect\Logger\Logger;
 use Signifyd\Connect\Model\CasedataFactory;


### PR DESCRIPTION
The subject reader is no longer located in Magento/Braintree -- Causing compilation issues