### PR TITLE
Updating addRecord method signature to match Monolog

### DIFF
--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -46,7 +46,7 @@ class Logger extends \Monolog\Logger
      * @param array $context
      * @return bool
      */
-    public function addRecord($level, $message, array $context = [])
+    public function addRecord(int $level, string $message, array $context = []): bool
     {
         if (isset($context['entity'])) {
             $log = $this->configHelper->getConfigData('signifyd/logs/log', $context['entity']);


### PR DESCRIPTION
Magento 2.4.4 updates the Monolog Logger package to v2.3. The method signature in the new version includes strict typing, causing fatal errors. Have not tested if there are other changes necessary.

```
Fatal error: Declaration of Signifyd\Connect\Logger\Logger::addRecord($level, $message, array $context = []) must be compatible with Monolog\Logger::addRecord(int $level, string $message, array $context = []): bool in /var/www/html/vendor/signifyd/module-connect/Logger/Logger.php on line 49
```