### PR TITLE
Removed duplicate call to starting env emulation

### DIFF
--- a/Controller/Webhooks/Index.php
+++ b/Controller/Webhooks/Index.php
@@ -246,7 +246,6 @@ class Index extends Action
 
             $this->logger->info("WEBHOOK: Processing case {$case->getId()}");
 
-            $this->emulation->startEnvironmentEmulation(0, 'adminhtml');
             $this->storeManagerInterface->setCurrentStore($case->getOrder()->getStore()->getStoreId());
 
             $currentCaseHash = sha1(implode(',', $case->getData()));


### PR DESCRIPTION
Removed duplicate call to \Magento\Store\Model\App\Emulation::startEnvironmentEmulation which was introduced in commit 7056aa0f4acf9d4972239d04f2214077f1b1541a.

It's found on line #219 and #249

https://github.com/signifyd/magento2/commit/7056aa0f4acf9d4972239d04f2214077f1b1541a#diff-4f47ced39b697ec0a489fe53ae2429f231c09430c54b8f75437adec7dd7f5af8L234