### PR TITLE
Adapt adyen-cc-method JS mixin for Adyen Magento module 8.2

### DIFF
--- a/view/frontend/web/js/model/adyen-cc-method-mixin.js
+++ b/view/frontend/web/js/model/adyen-cc-method-mixin.js
@@ -1,88 +1,102 @@
-define(function () {
-    'use strict';
-    var binValue;
-    var cardLast4;
-    var mixin = {
-        /**
-         *
-         * @param {Column} elem
-         */
-        renderSecureFields: function (key) {
-            var self = this;
+define(
+    [
+        'Magento_Checkout/js/model/quote',
+        'Adyen_Payment/js/model/installments',
+        'Adyen_Payment/js/model/adyen-configuration',
+    ],
+    function(
+        quote,
+        installmentsHelper,
+        adyenConfiguration,
+    ) {
+        'use strict';
+        var binValue;
+        var cardLast4;
+        var mixin = {
+            /**
+             *
+             * @param {Column} elem
+             */
+            renderSecureFields: function() {
+                var self = this;
 
-            if (!self.getClientKey) {
-                return;
-            }
-
-            self.installments(0);
-
-            // installments
-            var allInstallments = self.getAllInstallments();
-
-            self.cardComponent = self.checkoutComponent.create('card', {
-                enableStoreDetails: self.getEnableStoreDetails(),
-                brands: self.getAvailableCardTypeAltCodes(),
-                onChange: function(state, component) {
-                    self.placeOrderAllowed(!!state.isValid);
-                },
-                onBinValue: function (binData) {
-                    if (binData.binValue.length == 6) {
-                        binValue = binData.binValue;
-                    }
-                },
-                onFieldValid: function (onFieldValid) {
-                    if (onFieldValid.fieldType === 'encryptedCardNumber') {
-                        cardLast4 = onFieldValid.endDigits;
-                    }
-                },
-                // Keep onBrand as is until checkout component supports installments
-                onBrand: function(state) {
-                    // Define the card type
-                    // translate adyen card type to magento card type
-                    var creditCardType = self.getCcCodeByAltCode(
-                        state.brand);
-                    if (creditCardType) {
-                        // If the credit card type is already set, check if it changed or not
-                        if (!self.creditCardType() ||
-                            self.creditCardType() &&
-                            self.creditCardType() != creditCardType) {
-                            var numberOfInstallments = [];
-
-                            if (creditCardType in allInstallments) {
-                                // get for the creditcard the installments
-                                var installmentCreditcard = allInstallments[creditCardType];
-                                var grandTotal = quote.totals().grand_total;
-                                var precision = quote.getPriceFormat().precision;
-                                var currencyCode = quote.totals().quote_currency_code;
-
-                                numberOfInstallments = installmentsHelper.getInstallmentsWithPrices(
-                                    installmentCreditcard, grandTotal,
-                                    precision, currencyCode);
-                            }
-
-                            if (numberOfInstallments) {
-                                self.installments(numberOfInstallments);
-                            } else {
-                                self.installments(0);
-                            }
-                        }
-
-                        self.creditCardType(creditCardType);
-                    } else {
-                        self.creditCardType('');
-                        self.installments(0);
-                    }
+                if (!self.getClientKey) {
+                    return;
                 }
-            }).mount('#cardContainer');
-        },
-        getData: function (key) {
-            var returnInformation = this._super();
-            returnInformation.additional_data.cardBin = binValue;
-            returnInformation.additional_data.cardLast4 = cardLast4;
-            return returnInformation;
-        }
-    };
-    return function (target) {
-        return target.extend(mixin);
-    };
-});
+
+                self.installments(0);
+
+                // installments
+                var allInstallments = self.getAllInstallments();
+                self.cardComponent = self.checkoutComponent.create('card', {
+                    enableStoreDetails: self.getEnableStoreDetails(),
+                    brands: self.getAvailableCardTypeAltCodes(),
+                    hasHolderName: adyenConfiguration.getHasHolderName(),
+                    holderNameRequired: adyenConfiguration.getHasHolderName() &&
+                        adyenConfiguration.getHolderNameRequired(),
+                    onChange: function(state, component) {
+                        self.placeOrderAllowed(!!state.isValid);
+                        self.storeCc = !!state.data.storePaymentMethod;
+                    },
+                    onBinValue: function (binData) {
+                        if (binData.binValue.length == 6) {
+                            binValue = binData.binValue;
+                        }
+                    },
+                    onFieldValid: function (onFieldValid) {
+                        if (onFieldValid.fieldType === 'encryptedCardNumber') {
+                            cardLast4 = onFieldValid.endDigits;
+                        }
+                    },
+                    // Keep onBrand as is until checkout component supports installments
+                    onBrand: function(state) {
+                        // Define the card type
+                        // translate adyen card type to magento card type
+                        var creditCardType = self.getCcCodeByAltCode(
+                            state.brand);
+                        if (creditCardType) {
+                            // If the credit card type is already set, check if it changed or not
+                            if (!self.creditCardType() ||
+                                self.creditCardType() &&
+                                self.creditCardType() != creditCardType) {
+                                var numberOfInstallments = [];
+
+                                if (creditCardType in allInstallments) {
+                                    // get for the creditcard the installments
+                                    var installmentCreditcard = allInstallments[creditCardType];
+                                    var grandTotal = self.grandTotal();
+                                    var precision = quote.getPriceFormat().precision;
+                                    var currencyCode = quote.totals().quote_currency_code;
+
+                                    numberOfInstallments = installmentsHelper.getInstallmentsWithPrices(
+                                        installmentCreditcard, grandTotal,
+                                        precision, currencyCode);
+                                }
+
+                                if (numberOfInstallments) {
+                                    self.installments(numberOfInstallments);
+                                } else {
+                                    self.installments(0);
+                                }
+                            }
+
+                            self.creditCardType(creditCardType);
+                        } else {
+                            self.creditCardType('');
+                            self.installments(0);
+                        }
+                    }
+                }).mount('#cardContainer');
+            },
+            getData: function () {
+                var returnInformation = this._super();
+                returnInformation.additional_data.cardBin = binValue;
+                returnInformation.additional_data.cardLast4 = cardLast4;
+                return returnInformation;
+            }
+        };
+        return function (target) {
+            return target.extend(mixin);
+        };
+    }
+);


### PR DESCRIPTION
When installing Adyen module 8.2.1 and Signifyd, the adeyn-cc-method mixin raises an error when we start typing the credit card number. The mixin uses services that are not imported as dependencies.

![image](https://user-images.githubusercontent.com/13258841/171030522-ce49392e-88c9-435a-ba35-0fc4798881a5.png)

As a result, the bin is not collected, and on Adyen side, when installments are configured they are not displayed because of the JS error. Installments are displayed only when the credit card number is recognized (visa, mastercard, etc). So when the error is raised in the Signifyd mixin, it stops the script that displays the installments.