### PR TITLE
php8 fix; remove console logs

### DIFF
--- a/Block/Adminhtml/CaseInfo.php
+++ b/Block/Adminhtml/CaseInfo.php
@@ -92,7 +92,7 @@ class CaseInfo extends Template
      */
     public function getCaseScore()
     {
-        return floor($this->getCaseEntity()->getData('score'));
+        return $this->getCaseEntity()->getData('score') ? floor($this->getCaseEntity()->getData('score')) : '';
     }
 
     /**

--- a/view/frontend/web/js/view/signifyd-fingerprint.js
+++ b/view/frontend/web/js/view/signifyd-fingerprint.js
@@ -32,7 +32,7 @@ define([
             var me = this;
 
             if (typeof dataOrderSessionId !== 'undefined' && dataOrderSessionId.length > 0) {
-                console.log('Sending fingerprint...');
+                //console.log('Sending fingerprint...');
 
                 me.callScript(dataOrderSessionId);
 
@@ -42,8 +42,8 @@ define([
 
                 return true;
             } else {
-                console.log('Will not send fingerprint');
-                console.log(dataOrderSessionId);
+                //console.log('Will not send fingerprint');
+                //console.log(dataOrderSessionId);
 
                 return false;
             }


### PR DESCRIPTION
This is a small fix for passing a null to `floor`, which happens in admin orders in the sandbox. Also removing console logs on the frontend.