### PR TITLE
Add Restricted Payment Methods and Restricted Order States fields to configuration page

### DIFF
--- a/Model/Config/Source/OrderStates.php
+++ b/Model/Config/Source/OrderStates.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Signifyd\Connect\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class OrderStates implements OptionSourceInterface
+{
+    protected $orderConfig;
+
+    public function __construct(\Magento\Sales\Model\Order\Config $orderConfig)
+    {
+        $this->orderConfig = $orderConfig;
+    }
+
+    /**
+     * Returns array to be used in multiselect on back-end
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        // get available order states
+        $arr = [];
+        foreach ($this->orderConfig->getStates() as $code => $title) {
+            if (!empty($code) && !empty($title)) {
+                $arr[] = ['value' => $code, 'label' => __($title) . " [$code]"];
+            }
+        }
+        return $arr;
+    }
+}

--- a/Model/Config/Source/PaymentMethods.php
+++ b/Model/Config/Source/PaymentMethods.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Signifyd\Connect\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class PaymentMethods implements OptionSourceInterface
+{
+    protected $paymentHelper;
+
+    public function __construct(\Magento\Payment\Helper\Data $paymentHelper)
+    {
+        $this->paymentHelper = $paymentHelper;
+    }
+
+    /**
+     * Returns array to be used in multiselect on back-end
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        // get available payment methods
+        $arr = [];
+        foreach ($this->paymentHelper->getPaymentMethodList() as $code => $title) {
+            if (!empty($code) && !empty($title)) {
+                $arr[] = ['value' => $code, 'label' => __($title) . " [$code]"];
+            }
+        }
+        return $arr;
+    }
+}

--- a/etc/adminhtml/system/signifyd/general.xml
+++ b/etc/adminhtml/system/signifyd/general.xml
@@ -12,5 +12,17 @@
             <label>Signifyd API Key</label>
             <comment><![CDATA[Your API key can be found on the <a href="https://app.signifyd.com/settings" target="_blank" title="This external link will open in a new window">settings page</a> in the Signifyd console. Don't have an account? <a href="https://www.signifyd.com/contact/" target="_blank" title="This external link will open in a new window">Contact us</a>]]></comment>
         </field>
+                <field id="restrict_payment_methods" translate="label comment" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Restricted Payment Methods</label>
+            <comment>Orders placed using selected payment methods will be excluded from being sent to Signifyd. These orders will not be created in Signifyd and the extension will not interfere with the order workflow i.e. place the order on hold or capture the payment.</comment>
+            <source_model>Signifyd\Connect\Model\Config\Source\PaymentMethods</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
+        <field id="restrict_states_create" translate="label comment" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Restricted Order States</label>
+            <comment>Orders with these states will be excluded from being sent to Signifyd. E.g. by default, the extension restricts any action on payment_review state, to ensure the extension does not interfere with the payment workflow.</comment>
+            <source_model>Signifyd\Connect\Model\Config\Source\OrderStates</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
     </group>
 </include>


### PR DESCRIPTION
Messing with `core_config_data` table to configure payment methods and order states is both dangerous and cumbersome. So as a Magento developer and a consumer of this extension, I really hope that you merge this for a more comfortable user experience.

---

![image](https://user-images.githubusercontent.com/1337570/233284584-ac61ace0-2cd5-405b-b88f-4782ccdbcf4e.png)
