### PR TITLE
Added ACL config. Config cleanup.

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Signifyd_Connect::config_signifyd" title="Signifyd" translate="title"
+                                      sortOrder="20"/>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/adminhtml/system/signifyd.xml
+++ b/etc/adminhtml/system/signifyd.xml
@@ -3,7 +3,7 @@
     <section id="signifyd" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Signifyd</label>
         <tab>service</tab>
-        <resource>Magento_Integration::config_signifyd</resource>
+        <resource>Signifyd_Connect::config_signifyd</resource>
 
         <include path="Signifyd_Connect::system/signifyd/advanced.xml"/>
         <include path="Signifyd_Connect::system/signifyd/general.xml"/>

--- a/etc/adminhtml/system/signifyd/logs.xml
+++ b/etc/adminhtml/system/signifyd/logs.xml
@@ -2,15 +2,15 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="logs" translate="label" type="text" sortOrder="500" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Enable Logging</label>
-        <field id="log" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="log" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Log Options</label>
             <comment>Enables logging of errors related to the plugin for debugging and troubleshooting issues.</comment>
             <source_model>Signifyd\Connect\Model\System\Config\Source\Options\Loglevel</source_model>
         </field>
         <field id="version" translate="label comment" type="text" sortOrder="36" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Version</label>
+            <comment>The version number of the Signifyd extension.</comment>            
             <frontend_model>Signifyd\Connect\Block\Adminhtml\System\Config\Field\Version</frontend_model>
-            <comment>The version number of the Signifyd extension.</comment>
         </field>
         <field id="cron_data" translate="label comment" type="text" sortOrder="38" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Cron last run</label>

--- a/etc/adminhtml/system/signifyd/webhook.xml
+++ b/etc/adminhtml/system/signifyd/webhook.xml
@@ -6,9 +6,8 @@
             <label>Webhook Url</label>
             <comment><model>Signifyd\Connect\Model\WebhookLink</model></comment>
         </field>
-        <field id="register_webhook" translate="label comment" type="button" sortOrder="37" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="register_webhook" translate="label" type="button" sortOrder="37" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Register Webhook</label>
-            <comment />
             <frontend_model>Signifyd\Connect\Block\Adminhtml\System\Config\Button\Webhook</frontend_model>
         </field>
     </group>


### PR DESCRIPTION
Hi,

Looks like missed ACL configuration for control access for non-Admin users. In the same time, previously used ACL isn't present in Magentos (2.3 -  <= 2.4.4). So, in suggested PR:
1. Added ACL configuration with module namespace and replaces using reference for missed ACL.
2. A bit sorted system.xml configuration - added/removed comment for applying translations. 

Please review,